### PR TITLE
Wire Quantum DPI --run-engine to GF01 tick loop

### DIFF
--- a/src/ops/run_summaries.py
+++ b/src/ops/run_summaries.py
@@ -35,9 +35,14 @@ class RunSummary:
     loom_mode: Optional[str] = None
     codex_mode: Optional[str] = None
     runtime_total_ms: Optional[float] = None
+    runtime_engine_ms: Optional[float] = None
     status: str = "UNKNOWN"
     loom_p_blocks: Optional[int] = None
     loom_i_blocks: Optional[int] = None
+    loom_bytes: Optional[int] = None
+    peak_mem_mb: Optional[float] = None
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
     eta: Optional[float] = None
     phase_bins: Optional[int] = None
     fidelity_prob_l1: Optional[float] = None
@@ -91,9 +96,14 @@ class RunSummary:
             "loom_mode",
             "codex_mode",
             "runtime_total_ms",
+            "runtime_engine_ms",
             "status",
             "loom_p_blocks",
             "loom_i_blocks",
+            "loom_bytes",
+            "peak_mem_mb",
+            "error_code",
+            "error_message",
             "eta",
             "phase_bins",
             "fidelity_prob_l1",
@@ -117,9 +127,14 @@ class RunSummary:
             self.loom_mode,
             self.codex_mode,
             self.runtime_total_ms,
+            self.runtime_engine_ms,
             self.status,
             self.loom_p_blocks,
             self.loom_i_blocks,
+            self.loom_bytes,
+            self.peak_mem_mb,
+            self.error_code,
+            self.error_message,
             self.eta,
             self.phase_bins,
             self.fidelity_prob_l1,

--- a/tests/integration/test_dpi_quantum_engine_run.py
+++ b/tests/integration/test_dpi_quantum_engine_run.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_experiment_run_engine_executes_end_to_end(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    logs_root = tmp_path / "quantum_logs"
+    env = os.environ.copy()
+    existing_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(repo_root / "src") + (f":{existing_path}" if existing_path else "")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "dpi_quantum",
+        "--logs-dir",
+        str(logs_root),
+        "experiment",
+        "--name",
+        "spin_chain",
+        "--qubits",
+        "4",
+        "--ticks",
+        "4",
+        "--run-engine",
+    ]
+
+    completed = subprocess.run(cmd, capture_output=True, text=True, cwd=repo_root, env=env)
+
+    assert completed.returncode == 0, completed.stderr
+    assert "stub" not in completed.stdout.lower()
+
+    logs_dir = logs_root / "logs"
+    jsonl_path = logs_dir / "quantum_runs.jsonl"
+    csv_path = logs_dir / "quantum_runs.csv"
+    assert jsonl_path.exists()
+    assert csv_path.exists()
+
+    entries = [json.loads(line) for line in jsonl_path.read_text().splitlines() if line.strip()]
+    assert entries, "no run summaries were recorded"
+    last = entries[-1]
+
+    for field in [
+        "runtime_total_ms",
+        "runtime_engine_ms",
+        "ticks",
+        "loom_p_blocks",
+        "loom_i_blocks",
+        "loom_bytes",
+    ]:
+        assert last.get(field) not in (None, ""), f"missing {field}"
+
+    assert last.get("status") == "OK"
+    assert int(last.get("ticks")) >= 1
+    assert int(last.get("loom_p_blocks")) >= 1


### PR DESCRIPTION
## Summary
- connect `dpi_quantum` simulate/experiment `--run-engine` paths to the in-process GF01 tick loop using PFNA derived from TBP outputs
- capture engine runtime, Loom block metrics, and run identifiers in run-sheet entries while continuing existing DPI fidelity reporting
- add an acceptance-style integration test for `python -m dpi_quantum experiment --name spin_chain --qubits 4 --ticks 4 --run-engine`

## Testing
- pytest tests/integration/test_dpi_quantum_engine_run.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693e64fe680483338e909950671ffea3)